### PR TITLE
docs: add agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,65 @@
+# Agent Instructions — gogorichieblog
+
+## Purpose
+
+This repository is Richard Lewis’s personal blog, written since 2001.
+Create and update posts in his established voice: personal, practical,
+conversational, and grounded in real experience.
+
+## Content Guidelines
+
+- Write Hugo-compatible Markdown.
+- Review two or three related existing posts before drafting or revising content.
+- Match the front matter and file naming conventions used by similar posts.
+- Preserve Richard’s first-person voice and straightforward tone.
+- Use clear headings, short paragraphs, and practical examples.
+- Do not invent personal experiences, technical results, quotes, or sources.
+- Keep technical explanations accurate but accessible.
+
+## Repository Structure
+
+- `content/` contains blog posts and pages.
+- `themes/` contains the Hugo theme.
+- Site configuration controls navigation, taxonomy, and publishing behavior.
+- Do not modify generated output unless the repository explicitly tracks it.
+
+## Branch Naming
+
+Create draft branches using the date they are started:
+
+```text
+draft/YYYY-MM-DD
+```
+
+For example:
+
+```text
+draft/2026-08-07
+```
+
+Use one draft branch per post or focused update. Keep the branch scoped to
+that work and avoid unrelated changes.
+
+## Authoring Workflow
+
+1. Find two or three related existing posts for tone, structure, and front matter.
+2. Draft or update the Markdown source under `content/`.
+3. Verify internal links, image paths, code fences, headings, and front matter.
+4. Build the site locally before considering the work complete.
+
+## Validation
+
+Run the appropriate Hugo build command before finishing:
+
+```bash
+hugo --minify
+```
+
+Resolve build errors and avoid unrelated formatting or theme changes.
+
+## Guardrails
+
+- Do not publish, deploy, or change Netlify or Azure settings unless explicitly asked.
+- Do not rewrite unrelated posts.
+- Preserve existing URLs and filenames when editing published content.
+- Prefer small, focused commits and explain what changed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,16 @@ draft/2026-08-07
 Use one draft branch per post or focused update. Keep the branch scoped to
 that work and avoid unrelated changes.
 
+## Pull Requests
+
+Every repository change must be made through a pull request.
+
+- Never commit directly to `main`.
+- Create or update a focused draft branch, then open a pull request targeting
+  `main`.
+- Keep the pull request scoped to one post or focused update.
+- Do not merge a pull request unless explicitly asked.
+
 ## Authoring Workflow
 
 1. Find two or three related existing posts for tone, structure, and front matter.


### PR DESCRIPTION
## Summary

- add repository guidance for Hugo blog content
- standardize draft branch names as `draft/YYYY-MM-DD`
- require every repository change to go through a pull request

## Validation

Documentation-only change; no site build required.