### PR TITLE
docs: add blog post header template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,22 @@ conversational, and grounded in real experience.
 - Do not invent personal experiences, technical results, quotes, or sources.
 - Keep technical explanations accurate but accessible.
 
+## Required Post Header
+
+Every new blog post must begin as a Hugo draft using this front-matter template.
+Replace the title and date values for the new post; keep `draft: true`.
+
+```yaml
+---
+title: "Post Title"
+date: "YYYY-MM-DDTHH:MM:SS-05:00"
+draft: true
+---
+```
+
+Do not change a post to `draft: false` unless explicitly asked to prepare it
+for publication.
+
 ## Repository Structure
 
 - `content/` contains blog posts and pages.
@@ -25,16 +41,17 @@ conversational, and grounded in real experience.
 
 ## Branch Naming
 
-Create draft branches using the date they are started:
+Create draft branches for new blog posts using the date they are started and a
+kebab-case version of the post title:
 
 ```text
-draft/YYYY-MM-DD
+draft/YYYY-MM-DD/post-title
 ```
 
 For example:
 
 ```text
-draft/2026-08-07
+draft/2026-08-07/backlog-bankruptcy
 ```
 
 Use one draft branch per post or focused update. Keep the branch scoped to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,10 @@ for publication.
 
 ## Repository Structure
 
-- `content/` contains blog posts and pages.
+- `content/blog/` contains every blog post. Create and keep all blog-post
+  source files in this directory.
+- `content/` may contain other Hugo pages and sections, but must not contain
+  blog posts outside `content/blog/`.
 - `themes/` contains the Hugo theme.
 - Site configuration controls navigation, taxonomy, and publishing behavior.
 - Do not modify generated output unless the repository explicitly tracks it.
@@ -70,7 +73,7 @@ Every repository change must be made through a pull request.
 ## Authoring Workflow
 
 1. Find two or three related existing posts for tone, structure, and front matter.
-2. Draft or update the Markdown source under `content/`.
+2. Create or update blog-post Markdown source under `content/blog/`.
 3. Verify internal links, image paths, code fences, headings, and front matter.
 4. Build the site locally before considering the work complete.
 


### PR DESCRIPTION
## Summary

- require new Hugo posts to begin with a standard `draft: true` front-matter header
- require every blog-post source file to be created and kept under `content/blog/`
- standardize post branches as `draft/YYYY-MM-DD/post-title`

## Why

This makes new drafts consistent, keeps all posts in one predictable location, and keeps each post’s work isolated in a clearly named branch.

## Validation

- verified the updated `AGENTS.md` content on the draft branch
- documentation-only change; no site build required